### PR TITLE
Add/update license headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2019, Open Dynamic Robot Initiative
+Copyright (c) 2019, Max Planck Gesellschaft, New York University
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -43,3 +43,11 @@ This package is structured as follows:
 
   * src: Contains all the source code of this project
   * ccs: Contains the Code Composer Studio project files
+
+
+License
+-------
+
+BSD 3-Clause License
+
+Copyright (c) 2019, Max Planck Gesellschaft, New York University

--- a/src/canapi.cpp
+++ b/src/canapi.cpp
@@ -1,9 +1,33 @@
-/*
- * canapi.cpp
- *
- *  Created on: 25 Aug 2016
- *      Author: fwidmaier
- */
+// BSD 3-Clause License
+//
+// Copyright (c) 2019, Max Planck Gesellschaft, New York University
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include "canapi.h"
 

--- a/src/canapi.h
+++ b/src/canapi.h
@@ -1,3 +1,34 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2019, Max Planck Gesellschaft, New York University
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 /**
  * \brief API for more convenient use of the eCAN module
  *

--- a/src/dual_motor_torque_ctrl.c
+++ b/src/dual_motor_torque_ctrl.c
@@ -1,5 +1,6 @@
 // --COPYRIGHT--,BSD
 // Copyright (c) 2015, Texas Instruments Incorporated
+// Copyright (c) 2019, Max Planck Gesellschaft, New York University
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -29,10 +30,12 @@
 // OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 // EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // --/COPYRIGHT
-//! \file   solutions/instaspin_motion/src/proj_lab12c.c
+
+//! \file
 //! \brief Dual sensored speed control using SpinTAC
 //!
 //! (C) Copyright 2015, Texas Instruments, Inc.
+//! (C) Copyright 2019, Max Planck Gesellschaft, New York University
 
 //! \defgroup PROJ_LAB12C PROJ_LAB12C
 //@{

--- a/src/main_2mtr.h
+++ b/src/main_2mtr.h
@@ -2,6 +2,7 @@
 #define _MAIN_H_
 /* --COPYRIGHT--,BSD
  * Copyright (c) 2012, Texas Instruments Incorporated
+// Copyright (c) 2019, Max Planck Gesellschaft, New York University
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,11 +33,12 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * --/COPYRIGHT--*/
 
-//! \file   solutions/instaspin_foc/src/main.h
+//! \file
 //! \brief Defines the structures, global initialization, and functions used in
 //! \brief MAIN
 //!
 //! (C) Copyright 2011, Texas Instruments, Inc.
+//! (C) Copyright 2019, Max Planck Gesellschaft, New York University
 
 // **************************************************************************
 // the includes

--- a/src/main_helper.c
+++ b/src/main_helper.c
@@ -1,9 +1,34 @@
-/*
- * main_helper.c
- *
- *  Created on: Nov 3, 2016
- *      Author: fwidmaierlocal
- */
+// BSD 3-Clause License
+//
+// Copyright (c) 2019, Max Planck Gesellschaft, New York University
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 #include "main_helper.h"
 #include <math.h>
 #include "canapi.h"

--- a/src/main_helper.h
+++ b/src/main_helper.h
@@ -1,3 +1,34 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2019, Max Planck Gesellschaft, New York University
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 /**
  * \brief Various functions used in the main file.
  *

--- a/src/spintac_types.h
+++ b/src/spintac_types.h
@@ -1,8 +1,3 @@
-/**
- * \brief Definitions of types used for the SpinTAC modules
- *
- * Move this to a separate file to avoid circular includes in the current setup.
- */
 /* --COPYRIGHT--,BSD
  * Copyright (c) 2012, LineStream Technologies Incorporated
  * Copyright (c) 2012, Texas Instruments Incorporated
@@ -19,7 +14,7 @@
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
  *
-* *  Neither the names of Texas Instruments Incorporated, LineStream
+ * *  Neither the names of Texas Instruments Incorporated, LineStream
  *    Technologies Incorporated, nor the names of its contributors may be
  *    used to endorse or promote products derived from this software without
  *    specific prior written permission.
@@ -36,6 +31,12 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * --/COPYRIGHT--*/
+
+/**
+ * \brief Definitions of types used for the SpinTAC modules
+ *
+ * Move this to a separate file to avoid circular includes in the current setup.
+ */
 
 #ifndef SRC_SPINTAC_TYPES_H_
 #define SRC_SPINTAC_TYPES_H_

--- a/src/virtualspring.c
+++ b/src/virtualspring.c
@@ -1,9 +1,34 @@
-/*
- * virtualspring.c
- *
- *  Created on: 14 Jul 2016
- *      Author: fwidmaier
- */
+// BSD 3-Clause License
+//
+// Copyright (c) 2019, Max Planck Gesellschaft, New York University
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 // **************************************************************************
 // the includes
 #include "virtualspring.h"
@@ -60,7 +85,7 @@ void VIRTUALSPRING_run(VIRTUALSPRING_Handle vsHandle, _iq motorPosition_mrev)
 
     // First check if the spring is enabled.
     if (!spring->enabled)
-    	return;
+        return;
 
     // reset positon offset if flag is set
     if (spring->flagResetOffset) {
@@ -75,12 +100,12 @@ void VIRTUALSPRING_run(VIRTUALSPRING_Handle vsHandle, _iq motorPosition_mrev)
     //        - spring->encoderOffset
     //        + spring->equilibriumPosition;
     spring->deflection = UTILS_removePositionOffset(motorPosition_mrev,
-    		spring->encoderOffset,
-			spring->maxPosition_mrev);
+            spring->encoderOffset,
+            spring->maxPosition_mrev);
     // this offset has to be added, so remove negative
     spring->deflection = UTILS_removePositionOffset(spring->deflection,
-    		-spring->equilibriumPosition,
-			spring->maxPosition_mrev);
+            -spring->equilibriumPosition,
+            spring->maxPosition_mrev);
 
     return;
 }

--- a/src/virtualspring.h
+++ b/src/virtualspring.h
@@ -1,3 +1,34 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2019, Max Planck Gesellschaft, New York University
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 /**
  * Virtual Spring Module
  *


### PR DESCRIPTION
# Summary

- Add license headers to source files that did not have one yet.
- Add MPI/NYU as copyright holder for files that already included the
  header and were substantially modified/extended by us.
- Change copyright holder in LICENSE to MPI/NYU.